### PR TITLE
Moved search bar to right side of the navbar

### DIFF
--- a/partials/navigation.hbs
+++ b/partials/navigation.hbs
@@ -21,7 +21,7 @@
                   {{/each}}
 
                 </ul>
-                <form class="navbar-form navbar-left" role="search">
+                <form class="navbar-form navbar-right" role="search">
                     <div class="form-group">
                         <input class="search" type="text" placeholder="Search..."/>
                     </div>


### PR DESCRIPTION
Very minor, but it seemed a little odd to have the search bar at the come directly after the links in the navbar, so I changed the style of the search bar so that it is anchored to the right side of the screen.
