### PR TITLE
Corrected the name of the handlebar ghost_foot

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -67,7 +67,7 @@
     </footer>
 
     {{! Ghost outputs important scripts and data with this tag }}
-    {{ghost_foo }}
+    {{ghost_foot}}
 
     <script type="text/javascript" src="{{asset "js/scripts.min.js"}}"></script>
 			


### PR DESCRIPTION
By correcting the name of the handlebar ghost_foot users will be able to do code injections in Ghost Admin Blog Footer.

Image of ghost Admin below
![ghost_code_injection](https://cloud.githubusercontent.com/assets/7482285/13771126/f165d660-ea8b-11e5-9522-52cfbdc22c7a.JPG)
